### PR TITLE
Fix Spellscript spell_zuldrak_gymers_grab

### DIFF
--- a/src/server/scripts/Northrend/zone_zuldrak.cpp
+++ b/src/server/scripts/Northrend/zone_zuldrak.cpp
@@ -1140,7 +1140,9 @@ enum TheStormKingsVengeance
 {
     SPELL_RIDE_GYMER            = 43671,
     SPELL_GRABBED               = 55424,
-    SPELL_VARGUL_EXPLOSION      = 55569
+    SPELL_VARGUL_EXPLOSION      = 55569,
+    SPELL_HEALING_WINDS         = 55549,
+    NPC_STORM_CLOUD             = 29939
 };
 
 // 55516 - Gymer's Grab
@@ -1161,6 +1163,9 @@ class spell_zuldrak_gymers_grab : public SpellScript
         args.AddSpellBP0(2);
         GetHitCreature()->CastSpell(GetCaster(), SPELL_RIDE_GYMER, args);
         GetHitCreature()->CastSpell(GetHitCreature(), SPELL_GRABBED, true);
+
+        if (GetHitCreature()->GetEntry() == NPC_STORM_CLOUD) // Storm Cloud
+        GetHitCreature()->CastSpell(GetCaster(), SPELL_HEALING_WINDS, true); // Healing Winds
     }
 
     void Register() override


### PR DESCRIPTION
What's missing is that when a player grabs the storm cloud, the healing effect is triggered.

This fix fixes that.
I tested it in-game and it works.